### PR TITLE
add isExecutable -- accessSync raises an exception instead of returni…

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,4 @@
+.idea/**
 .vscode/**
 typings/**
 out/test/**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-tidyhtml",
     "displayName": "vscode-tidyhtml",
     "description": "format html with tidy html",
-    "version": "1.9.0",
+    "version": "1.10.0",
     "publisher": "anweber",
     "license": "MIT",
     "engines": {


### PR DESCRIPTION
…ng a boolean


This time I tested the changes :-)

The 1.9 version may have worked fine on Windows, but refused to work on MacOS (untested on Linux)